### PR TITLE
Fix 8-bit BMP reconstruction failure in RLE

### DIFF
--- a/include/BmpBaseDataProvider.h
+++ b/include/BmpBaseDataProvider.h
@@ -3,7 +3,6 @@
 
 #include "DataProvider.h"
 #include "bmpbase.h"
-
 class BmpBaseDataProvider : public DataProvider {
 private:
     BmpBase bmpBase; 
@@ -23,11 +22,17 @@ public:
         //Convert  BitmapFileHeader to byte array 
         const auto& fileHeader = bmpBase.getFileHeader();
         headerData.insert(headerData.end(), reinterpret_cast<const uint8_t*>(&fileHeader), 
-                          reinterpret_cast<const uint8_t*>(&fileHeader) + sizeof(fileHeader));
+                            reinterpret_cast<const uint8_t*>(&fileHeader) + sizeof(fileHeader));
         //Convert BitmapInfoHeader to byte array
         const auto& infoHeader = bmpBase.getInfoHeader();
         headerData.insert(headerData.end(), reinterpret_cast<const uint8_t*>(&infoHeader), 
-                          reinterpret_cast<const uint8_t*>(&infoHeader) + sizeof(infoHeader));
+                            reinterpret_cast<const uint8_t*>(&infoHeader) + sizeof(infoHeader));
+        //Convert ColorPalette to byte array
+        if (bmpBase.getInfoHeader().biBitCount == 8) {
+            const auto& colorPalette = bmpBase.getColorPalette();
+            headerData.insert(headerData.end(), reinterpret_cast<const uint8_t*>(colorPalette.data()), 
+                              reinterpret_cast<const uint8_t*>(colorPalette.data()) + colorPalette.size() * sizeof(BitmapColorPalette));
+        }
         return headerData;
     }
 };

--- a/include/bmpbase.h
+++ b/include/bmpbase.h
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <fstream>
 #include "bmpheader.h"
-#include <iostream>
+
 struct Color {
     uint8_t r, g, b;
 };

--- a/include/bmpbase.h
+++ b/include/bmpbase.h
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <fstream>
 #include "bmpheader.h"
-
+#include <iostream>
 struct Color {
     uint8_t r, g, b;
 };
@@ -16,7 +16,7 @@ class BmpBase {
 public:
     // Constructor and Destructor
     BmpBase(); // default constructor
-    BmpBase(int width, int height, int bitDepth = 24);
+    BmpBase(int width, int height, int bitDepth );
     ~BmpBase();
 
     //bmp image flipper
@@ -30,6 +30,10 @@ public:
     // get info header
     const BitmapInfoHeader& getInfoHeader() const {
         return infoHeader;
+    }
+    // get color palette
+    const std::vector<BitmapColorPalette>& getColorPalette() const {
+        return ColorPalette;
     }
     // get pixel data
     const std::vector<uint8_t>& getPixelData() const {


### PR DESCRIPTION
Addressed the reconstruction issue for 8-bit BMP images using run-length encoding by ensuring the color palette is correctly included in the header data. Removed unnecessary library dependencies to streamline the code.

Fixes #11